### PR TITLE
Add CDF APIs

### DIFF
--- a/src/api/cdf/index.js
+++ b/src/api/cdf/index.js
@@ -1,0 +1,10 @@
+import express from 'express'
+let router = express.Router()
+
+import labs from './labs'
+import printers from './printers'
+
+router.use('/labs', labs)
+router.use('/printers', printers)
+
+export default router

--- a/src/api/cdf/labs/index.js
+++ b/src/api/cdf/labs/index.js
@@ -2,9 +2,6 @@ import express from 'express'
 let router = express.Router()
 
 import list from './routes/list'
-
-import Validator from '../../utils/validator'
-
 router.get('/', list)
 
 export default router

--- a/src/api/cdf/labs/index.js
+++ b/src/api/cdf/labs/index.js
@@ -1,0 +1,10 @@
+import express from 'express'
+let router = express.Router()
+
+import list from './routes/list'
+
+import Validator from '../../utils/validator'
+
+router.get('/', list)
+
+export default router

--- a/src/api/cdf/labs/routes/list.js
+++ b/src/api/cdf/labs/routes/list.js
@@ -1,0 +1,28 @@
+import http from 'http'
+
+export default function list(req, res, next) {
+  let options  =  {
+    host: req.query.host || 'www.cdf.toronto.edu',
+    port: req.query.port || 80,
+    path: req.query.path || '/~g3cheunh/cdflabs.json'
+  }
+
+  http.get(options, response  => {
+    if (response.statusCode != 200) {
+      let err = new Error('CDF data is currently inaccessible.')
+      err.status = 500
+      return next(err)
+    }
+
+    let data = ''
+    response.on('data', chunk => {
+      data += chunk
+    })
+
+    response.on('end', () => {
+      res.charset = 'utf-8'
+      res.set('Content-Type', 'application/json')
+      res.send(data)
+    })
+  })
+}

--- a/src/api/cdf/printers/index.js
+++ b/src/api/cdf/printers/index.js
@@ -2,9 +2,6 @@ import express from 'express'
 let router = express.Router()
 
 import list from './routes/list'
-
-import Validator from '../../utils/validator'
-
 router.get('/', list)
 
 export default router

--- a/src/api/cdf/printers/index.js
+++ b/src/api/cdf/printers/index.js
@@ -1,0 +1,10 @@
+import express from 'express'
+let router = express.Router()
+
+import list from './routes/list'
+
+import Validator from '../../utils/validator'
+
+router.get('/', list)
+
+export default router

--- a/src/api/cdf/printers/routes/list.js
+++ b/src/api/cdf/printers/routes/list.js
@@ -1,0 +1,28 @@
+import http from 'http'
+
+export default function list(req, res, next) {
+  let options  =  {
+    host: req.query.host || 'www.cdf.toronto.edu',
+    port: req.query.port || 80,
+    path: req.query.path || '/~g3cheunh/cdfprinters.json'
+  }
+
+  http.get(options, response  => {
+    if (response.statusCode != 200) {
+      let err = new Error('CDF data is currently inaccessible.')
+      err.status = 500
+      return next(err)
+    }
+
+    let data = ''
+    response.on('data', chunk => {
+      data += chunk
+    })
+
+    response.on('end', () => {
+      res.charset = 'utf-8'
+      res.set('Content-Type', 'application/json')
+      res.send(data)
+    })
+  })
+}

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import exams from './api/exams'
 import food from './api/food'
 import textbooks from './api/textbooks'
 import transportation from './api/transportation'
+import cdf from './api/cdf'
 
 let test = process.argv.join().match('/ava/')
 let enableSync = process.env.COBALT_ENABLE_DB_SYNC || 'true'
@@ -39,6 +40,7 @@ app.use(`/${apiVersion}/exams`, exams)
 app.use(`/${apiVersion}/food`, food)
 app.use(`/${apiVersion}/textbooks`, textbooks)
 app.use(`/${apiVersion}/transportation`, transportation)
+app.use(`/${apiVersion}/cdf`, cdf)
 
 // Error handlers
 app.use((req, res, next) => {

--- a/test/cdf/test.js
+++ b/test/cdf/test.js
@@ -1,0 +1,52 @@
+import test from 'ava'
+import request from 'supertest'
+
+import cobalt from '../../src/index'
+
+test.cb('/labs', t => {
+  request(cobalt.Server)
+    .get('/1.0/cdf/labs')
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .end((err, res) => {
+      if (err) t.fail(err.message)
+      t.pass()
+      t.end()
+    })
+})
+
+test.cb('/printers', t => {
+  request(cobalt.Server)
+    .get('/1.0/cdf/printers')
+    .expect('Content-Type', /json/)
+    .expect(200)
+    .end((err, res) => {
+      if (err) t.fail(err.message)
+      t.pass()
+      t.end()
+    })
+})
+
+test.cb('/labs?path=abc.json', t => {
+  request(cobalt.Server)
+    .get('/1.0/cdf/labs?path=abc.json')
+    .expect('Content-Type', /json/)
+    .expect(500)
+    .end((err, res) => {
+      if (err) t.fail(err.message)
+      t.pass()
+      t.end()
+    })
+})
+
+test.cb('/labs?path=abc.json', t => {
+  request(cobalt.Server)
+    .get('/1.0/cdf/printers?path=abc.json')
+    .expect('Content-Type', /json/)
+    .expect(500)
+    .end((err, res) => {
+      if (err) t.fail(err.message)
+      t.pass()
+      t.end()
+    })
+})


### PR DESCRIPTION
This endpoint just mirrors @arkon's [cdf-scrapers](https://github.com/arkon/cdf-scrapers), for both labs and printers.
