### PR TITLE
Allow modified database name, host, and port

### DIFF
--- a/src/db/index.js
+++ b/src/db/index.js
@@ -30,8 +30,10 @@ db.update = (collection) => {
         }
 
         let shell = childProcess.spawn('mongoimport', [
-          '-d', 'cobalt',
+          '-d', mongoose.connection.name,
           '-c', collection,
+          '--host', mongoose.connection.host,
+          '--port', mongoose.connection.port,
           '--file', filePath
         ])
 


### PR DESCRIPTION
While still not fully supporting mongo URIs (options, for example, are ignored). This does support mongodb://host:port/name style URIs. Issue #79.
